### PR TITLE
Added Color#mix(other_color)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ color.desaturate_percent(20)
 color.desaturate!(20)
 color.desaturate_percent!(20)
 
+color.invert!
+
+# Mixing colors:
+color.mix(other_color, 20) # Mix 20% of other color into current one
+color.mix(other_color) # 50% by default
+color.mix!(other_color, 20)
+color.mix!(other_color)
+
 # Also you can adjust color HSL (hue, saturation, and lightness values) manually:
 color.hue = 0.1
 color.saturation = 0.2

--- a/spec/rgb/color_spec.rb
+++ b/spec/rgb/color_spec.rb
@@ -173,6 +173,31 @@ describe RGB::Color do
         expect(color.to_hsl).to be_eql [0, 0, 0.0]
       end
     end
+
+    describe :mix do
+      it 'should mix two colors' do
+        color1 = RGB::Color.from_rgb_hex('#1F77B4')
+        color2 = RGB::Color.from_rgb_hex('#D62728')
+
+        mix_50pct = color1.mix(color2)
+        mix_10pct = color1.mix(color2, 10)
+
+        expect(mix_50pct.to_rgb_hex).to be_eql '#7B4F6E'
+
+        expect(mix_10pct.to_rgb_hex).to be_eql '#316FA6'
+      end
+    end
+
+    describe :mix! do
+      it 'should mix other color in-place' do
+        color1 = RGB::Color.from_rgb_hex('#1F77B4')
+        color2 = RGB::Color.from_rgb_hex('#D62728')
+
+        color1.mix!(color2, 10)
+
+        expect(color1.to_rgb_hex).to be_eql '#316FA6'
+      end
+    end
   end
 
   describe 'Output' do


### PR DESCRIPTION
I have stolen method of mixing two colors from here: https://github.com/chriseppstein/compass-colors/blob/master/lib/compass-colors/sass_extensions.rb#L86 and added it to rgb.

Useful example:

``` ruby
color1 = Color.from_rgb_hex('#1f77b4')
color2 = Color.from_rgb_hex('#d62728')

COUNT = 30
palette = COUNT.times.map{|i| color1.mix(color2, (i*100.0/COUNT))}
# => 30-colors palette with smooth transition from blue to red
```
